### PR TITLE
Add .NET API Search Command

### DIFF
--- a/src/Patek/Data/SearchResult.cs
+++ b/src/Patek/Data/SearchResult.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Patek.Data
+{
+    [JsonObject]
+    public class SearchResult
+    {
+        [JsonProperty("displayName")]
+        public string DisplayName { get; set; }
+        [JsonProperty("url")]
+        public string Url { get; set; }
+        [JsonProperty("itemType")]
+        public string ItemType { get; set; }
+        [JsonProperty("itemKind")]
+        public string ItemKind { get; set; }
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+}

--- a/src/Patek/Data/SearchResults.cs
+++ b/src/Patek/Data/SearchResults.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Patek.Data
+{
+    [JsonObject]
+    public class SearchResults
+    {
+        [JsonProperty("results")]
+        public IReadOnlyList<SearchResult> Results { get; set; }
+    }
+}

--- a/src/Patek/Modules/DotNetApiSearchModule.cs
+++ b/src/Patek/Modules/DotNetApiSearchModule.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Newtonsoft.Json;
+using Patek.Data;
+
+namespace Patek.Modules
+{
+    public class DotNetApiSearchModule : PatekModuleBase
+    {
+        /// <summary>
+        ///     Regular expression that determines what search queries are valid.
+        ///     This is stated in error messages when invalid terms are searched.
+        /// </summary>
+        private const string SearchTermRegex = @"^[A-Za-z][A-Za-z0-9\\.<>,]+$";
+        
+        /// <summary>
+        ///     Up to the first N results to display in the embed.
+        /// </summary>
+        private const int NumResultsToDisplay = 3;
+        
+        [Command(".net")]
+        [Alias("search", "net", "msftdocs", "c#docs", "netdocs", ".netdocs", "dotnet", "dotnetdocs")]
+        [Summary("Searches the .NET API Browser for the given search term.")]
+        public async Task Search([Remainder] string searchTerm)
+        {
+            SearchResults results = null;
+            try
+            {
+                results = await GetMsdnResultsAsync(searchTerm);
+            }
+            catch (ArgumentException e)
+            {
+                // is it bad practice to return exception messages?
+                await ReplyAsync(e.Message);
+                return;
+            }
+           
+            // non-success error code
+            if (results == null)
+            {
+                await ReplyAsync("Encountered an error trying to get results from MSDN.");
+            }
+            // no results
+            else if (results.Results.Count == 0)
+            {
+                await ReplyAsync("Search returned no results.");
+            }
+            // results are not null and contain at least one value
+            // so build an embed
+            else
+            {
+                var e = BuildResultsEmbed(results, searchTerm);
+                await ReplyAsync($"First {Math.Min(results.Results.Count, NumResultsToDisplay)} results:", embed: e);
+            }
+        }
+
+        /// <summary>
+        ///     Builds an Embed for the given SearchResults.
+        /// </summary>
+        /// <param name="results"> The search results to display in the embed. Assumed not null. </param>
+        /// <param name="searchTerm"> The search term that produced these results. Assumed not null. </param>
+        /// <returns> A new Embed instance containing the search results information. </returns>
+        private static Embed BuildResultsEmbed(SearchResults results, string searchTerm)
+        {
+            var eb = new EmbedBuilder();
+            eb.WithCurrentTimestamp();
+            eb.WithTitle($".NET API Browser Search Results: \"{searchTerm}\"");
+            // .NET purple
+            eb.WithColor(new Color(104, 33, 122));
+            
+            // use the embed description to show all results
+            // making the assumption that I don't need to worry about the embed description field
+            // limit
+            var sb = new StringBuilder();
+            foreach (var x in results.Results.Take(NumResultsToDisplay))
+            {
+                sb.AppendLine($"{x.ItemKind} [{x.DisplayName}]({x.Url})\n{x.Description}");
+            }
+            // include a link to the website itself that includes all results
+            sb.AppendLine($"[Find more results in the .NET API Browser]{GetMsdnFrontEndSearch(searchTerm)}");
+            eb.WithDescription(sb.ToString());
+
+            return eb.Build();
+        }
+        
+        /// <summary>
+        ///     Gets the query string of the docs.microsoft.com api browser with the search parameter populated.
+        /// </summary>
+        /// <param name="searchTerm"> The term to search for. Assumes not null or whitespace. </param>
+        /// <returns> The query string with the url encoded search term. </returns>
+        private static string GetMsdnApiSearchUrl(string searchTerm)
+            => $"https://docs.microsoft.com/api/apibrowser/dotnet/search?search={WebUtility.UrlEncode(searchTerm)}";
+
+        /// <summary>
+        ///     Gets the query string of the front-end url for the given search parameter.
+        ///     This is what users will see in their web browser.
+        /// </summary>
+        /// <param name="searchTerm"> The term to search for. Assumes not null or whitespace. </param>
+        /// <returns> The query string with the url encoded search term. </returns>
+        private static string GetMsdnFrontEndSearch(string searchTerm)
+            => $"https://docs.microsoft.com/en-us/dotnet/api/?term={WebUtility.UrlEncode(searchTerm)}";
+
+        /// <summary>
+        ///     Gets the search results for a given search term.
+        /// </summary>
+        /// <param name="s"> The string to search for. </param>
+        /// <returns> The resulting search terms, if any. </returns>
+        private async Task<SearchResults> GetMsdnResultsAsync(string s)
+        {
+            // check for null parameter
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                throw new ArgumentNullException(nameof(s), "The supplied search term may not be null or whitespace.");
+            }
+            // trim whitespace, then check that it matches the regex for valid search terms
+            s = s.Trim();
+            if (!Regex.IsMatch(SearchTermRegex, s))
+            {
+                throw new ArgumentException(paramName: nameof(s), message:
+                    "The search term contained invalid characters.");
+            }
+            using (var client = new HttpClient())
+            {
+                // GET the api query
+                var result = await client.GetAsync(GetMsdnApiSearchUrl(s));
+                if (result.IsSuccessStatusCode)
+                {
+                    // read the contents into a json reader
+                    return JsonConvert.DeserializeObject<SearchResults>(await result.Content.ReadAsStringAsync());
+                }
+            }
+            // non success status code
+            return null;
+        }
+    }
+}

--- a/src/Patek/Modules/DotNetApiSearchModule.cs
+++ b/src/Patek/Modules/DotNetApiSearchModule.cs
@@ -56,7 +56,7 @@ namespace Patek.Modules
             else
             {
                 var e = BuildResultsEmbed(results, searchTerm);
-                await ReplyAsync($"First {Math.Min(results.Results.Count, NumResultsToDisplay)} results:", embed: e);
+                await ReplyAsync($"{results.Results.Count} result(s):", embed: e);
             }
         }
 
@@ -70,7 +70,7 @@ namespace Patek.Modules
         {
             var eb = new EmbedBuilder();
             eb.WithCurrentTimestamp();
-            eb.WithTitle($".NET API Browser Search Results: \"{searchTerm}\"");
+            eb.WithTitle($".NET API Search: \"{searchTerm}\"");
             // .NET purple
             eb.WithColor(new Color(104, 33, 122));
             
@@ -84,7 +84,7 @@ namespace Patek.Modules
                 sb.AppendLine($"{x.ItemKind} [{x.DisplayName}]({x.Url})\n{WebUtility.HtmlDecode(x.Description)}\n");
             }
             // include a link to the website itself that includes all results
-            sb.AppendLine($"[Find more results in the .NET API Browser]({GetMsdnFrontEndSearch(searchTerm)})");
+            sb.AppendLine($"[View all results in the .NET API Browser]({GetMsdnFrontEndSearch(searchTerm)})");
             eb.WithDescription(sb.ToString());
 
             return eb.Build();

--- a/src/Patek/Patek.csproj
+++ b/src/Patek/Patek.csproj
@@ -1,24 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="4.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Nett" Version="0.10.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\lib\Discord.Net\src\Discord.Net.Commands\Discord.Net.Commands.csproj" />
     <ProjectReference Include="..\..\lib\Discord.Net\src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Patek/Patek.csproj
+++ b/src/Patek/Patek.csproj
@@ -1,19 +1,24 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="4.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Nett" Version="0.10.0" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\lib\Discord.Net\src\Discord.Net.Commands\Discord.Net.Commands.csproj" />
     <ProjectReference Include="..\..\lib\Discord.Net\src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adds a command which can search the .NET API. [This is built on the same API that serves the docs.microsoft.com .NET API Browser.](https://docs.microsoft.com/en-us/dotnet/api/)

The command syntax is: `/.net <search query>`. I've also provided aliases.

There's an issue in the browser where it won't show class names in the Description field, which is carried over to this too. [Example: System.Security.Cryptography.Xml.KeyInfoNode(XmlElement) ](https://docs.microsoft.com/en-us/dotnet/api/?term=System.Security.Cryptography.Xml.KeyInfoNode)
Also, the search bar's filtering rejects parenthesis. I've copied their regex and use it to validate inputs.

The first 3 results are shown in an embed, with their names (as links) and descriptions. There's also a link for viewing all of the results online as well.

## Example Usage
![image](https://user-images.githubusercontent.com/16418643/50545675-e6ce6d00-0bcd-11e9-9e1d-c8fe8c32063b.png)



